### PR TITLE
Fixes and improvements to the API

### DIFF
--- a/dprec/mat3.go
+++ b/dprec/mat3.go
@@ -26,6 +26,14 @@ func IdentityMat3() Mat3 {
 	return result
 }
 
+func TransposedMat3(m Mat3) Mat3 {
+	return NewMat3(
+		m.M11, m.M21, m.M31,
+		m.M12, m.M22, m.M32,
+		m.M13, m.M23, m.M33,
+	)
+}
+
 func TranslationMat3(x, y float64) Mat3 {
 	result := IdentityMat3()
 	result.M13 = x

--- a/dprec/mat3_test.go
+++ b/dprec/mat3_test.go
@@ -55,6 +55,15 @@ var _ = Describe("Mat3", func() {
 		Expect(transformedVector).To(HaveVec3Coords(vector.X, vector.Y, vector.Z))
 	})
 
+	Specify("TransposedMat3", func() {
+		result := TransposedMat3(matrix)
+		Expect(result).To(HaveMat3Elements(
+			0.1, 0.4, 0.7,
+			0.2, 0.5, 0.8,
+			0.3, 0.6, 0.9,
+		))
+	})
+
 	Specify("TranslationMat3", func() {
 		translationMatrix := TranslationMat3(2.0, -3.0)
 		transformedVector := Mat3Vec3Prod(translationMatrix, vector)

--- a/dprec/mat4.go
+++ b/dprec/mat4.go
@@ -397,6 +397,22 @@ func (m Mat4) Rotation() Quat {
 	return UnitQuat(NewQuat(w, x, y, z))
 }
 
+func (m Mat4) TRS() (Vec3, Quat, Vec3) {
+	translation := m.Translation()
+	scale := m.Scale()
+	m.M11 /= scale.X
+	m.M21 /= scale.X
+	m.M31 /= scale.X
+	m.M12 /= scale.Y
+	m.M22 /= scale.Y
+	m.M32 /= scale.Y
+	m.M13 /= scale.Z
+	m.M23 /= scale.Z
+	m.M33 /= scale.Z
+	rotation := m.Rotation()
+	return translation, rotation, scale
+}
+
 func (m Mat4) RowMajorArray() [16]float64 {
 	return [16]float64{
 		m.M11, m.M12, m.M13, m.M14,

--- a/dprec/mat4.go
+++ b/dprec/mat4.go
@@ -356,7 +356,11 @@ func (m Mat4) Scale() Vec3 {
 	)
 }
 
-func (m Mat4) RotationQuat() Quat {
+// Rotation returns the rotation that is represented by this matrix.
+// NOTE: This function assumes that the matrix has identity scale. If you
+// want to get the rotation of a matrix that has non-identity scale, consider
+// using the TRS method.
+func (m Mat4) Rotation() Quat {
 	// This is calculated by inversing the equations for
 	// quat.OrientationX, quat.OrientationY and quat.OrientationZ.
 

--- a/dprec/mat4.go
+++ b/dprec/mat4.go
@@ -29,6 +29,15 @@ func IdentityMat4() Mat4 {
 	return result
 }
 
+func TransposedMat4(m Mat4) Mat4 {
+	return NewMat4(
+		m.M11, m.M21, m.M31, m.M41,
+		m.M12, m.M22, m.M32, m.M42,
+		m.M13, m.M23, m.M33, m.M43,
+		m.M14, m.M24, m.M34, m.M44,
+	)
+}
+
 func TranslationMat4(x, y, z float64) Mat4 {
 	result := IdentityMat4()
 	result.M14 = x

--- a/dprec/mat4_test.go
+++ b/dprec/mat4_test.go
@@ -333,6 +333,18 @@ var _ = Describe("Mat4", func() {
 		Expect(rotatedVector).To(HaveVec3Coords(0.86602540378443870761, 0.0, -0.5))
 	})
 
+	Specify("#TRS", func() {
+		translation := NewVec3(15.0, 5.0, -3.0)
+		rotation := RotationQuat(Degrees(30), BasisXVec3())
+		scale := NewVec3(0.1, 0.5, 0.3)
+		matrix := TRSMat4(translation, rotation, scale)
+
+		t, r, s := matrix.TRS()
+		Expect(t).To(HaveVec3Coords(translation.X, translation.Y, translation.Z))
+		Expect(r).To(HaveQuatCoords(rotation.W, rotation.X, rotation.Y, rotation.Z))
+		Expect(s).To(HaveVec3Coords(scale.X, scale.Y, scale.Z))
+	})
+
 	Specify("#RowMajorArray", func() {
 		array := matrix.RowMajorArray()
 		Expect(array[0]).To(EqualFloat64(0.1))

--- a/dprec/mat4_test.go
+++ b/dprec/mat4_test.go
@@ -322,13 +322,13 @@ var _ = Describe("Mat4", func() {
 		))
 	})
 
-	Specify("#RotationQuat", func() {
+	Specify("#Rotation", func() {
 		matrix = IdentityMat4()
-		quat := matrix.RotationQuat()
+		quat := matrix.Rotation()
 		Expect(quat).To(HaveQuatCoords(1.0, 0.0, 0.0, 0.0))
 
 		matrix = RotationMat4(Degrees(30), 0.0, 1.0, 0.0)
-		quat = matrix.RotationQuat()
+		quat = matrix.Rotation()
 		rotatedVector := QuatVec3Rotation(quat, NewVec3(1.0, 0.0, 0.0))
 		Expect(rotatedVector).To(HaveVec3Coords(0.86602540378443870761, 0.0, -0.5))
 	})

--- a/dprec/mat4_test.go
+++ b/dprec/mat4_test.go
@@ -53,6 +53,16 @@ var _ = Describe("Mat4", func() {
 		Expect(transformedVector).To(HaveVec4Coords(vector.X, vector.Y, vector.Z, vector.W))
 	})
 
+	Specify("TransposedMat4", func() {
+		result := TransposedMat4(matrix)
+		Expect(result).To(HaveMat4Elements(
+			0.1, 0.5, 0.9, 1.3,
+			0.2, 0.6, 1.0, 1.4,
+			0.3, 0.7, 1.1, 1.5,
+			0.4, 0.8, 1.2, 1.6,
+		))
+	})
+
 	Specify("TranslationMat4", func() {
 		translationMatrix := TranslationMat4(2.0, -3.0, 4.0)
 		transformedVector := Mat4Vec4Prod(translationMatrix, vector)

--- a/dprec/util.go
+++ b/dprec/util.go
@@ -7,25 +7,25 @@ const (
 	Epsilon = float64(0.000000000001)
 )
 
-func Abs(value float64) float64 {
-	return math.Abs(value)
+func Abs[T ~float64](value T) T {
+	return T(math.Abs(float64(value)))
 }
 
-func Max(a, b float64) float64 {
+func Max[T ~float64](a, b T) T {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func Min(a, b float64) float64 {
+func Min[T ~float64](a, b T) T {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func Clamp(value, min, max float64) float64 {
+func Clamp[T ~float64](value, min, max T) T {
 	if value < min {
 		return min
 	}
@@ -35,8 +35,8 @@ func Clamp(value, min, max float64) float64 {
 	return value
 }
 
-func Mix(a, b, amount float64) float64 {
-	return a*(1.0-amount) + b*amount
+func Mix[T ~float64](a, b T, amount float64) T {
+	return T(float64(a)*(1.0-amount) + float64(b)*amount)
 }
 
 func Eq(a, b float64) bool {

--- a/sprec/mat3.go
+++ b/sprec/mat3.go
@@ -26,6 +26,14 @@ func IdentityMat3() Mat3 {
 	return result
 }
 
+func TransposedMat3(m Mat3) Mat3 {
+	return NewMat3(
+		m.M11, m.M21, m.M31,
+		m.M12, m.M22, m.M32,
+		m.M13, m.M23, m.M33,
+	)
+}
+
 func TranslationMat3(x, y float32) Mat3 {
 	result := IdentityMat3()
 	result.M13 = x

--- a/sprec/mat3_test.go
+++ b/sprec/mat3_test.go
@@ -55,6 +55,15 @@ var _ = Describe("Mat3", func() {
 		Expect(transformedVector).To(HaveVec3Coords(vector.X, vector.Y, vector.Z))
 	})
 
+	Specify("TransposedMat3", func() {
+		result := TransposedMat3(matrix)
+		Expect(result).To(HaveMat3Elements(
+			0.1, 0.4, 0.7,
+			0.2, 0.5, 0.8,
+			0.3, 0.6, 0.9,
+		))
+	})
+
 	Specify("TranslationMat3", func() {
 		translationMatrix := TranslationMat3(2.0, -3.0)
 		transformedVector := Mat3Vec3Prod(translationMatrix, vector)

--- a/sprec/mat4.go
+++ b/sprec/mat4.go
@@ -29,6 +29,15 @@ func IdentityMat4() Mat4 {
 	return result
 }
 
+func TransposedMat4(m Mat4) Mat4 {
+	return NewMat4(
+		m.M11, m.M21, m.M31, m.M41,
+		m.M12, m.M22, m.M32, m.M42,
+		m.M13, m.M23, m.M33, m.M43,
+		m.M14, m.M24, m.M34, m.M44,
+	)
+}
+
 func TranslationMat4(x, y, z float32) Mat4 {
 	result := IdentityMat4()
 	result.M14 = x

--- a/sprec/mat4.go
+++ b/sprec/mat4.go
@@ -348,24 +348,6 @@ func (m Mat4) Translation() Vec3 {
 	return NewVec3(m.M14, m.M24, m.M34)
 }
 
-func (m Mat4) RowMajorArray() [16]float32 {
-	return [16]float32{
-		m.M11, m.M12, m.M13, m.M14,
-		m.M21, m.M22, m.M23, m.M24,
-		m.M31, m.M32, m.M33, m.M34,
-		m.M41, m.M42, m.M43, m.M44,
-	}
-}
-
-func (m Mat4) ColumnMajorArray() [16]float32 {
-	return [16]float32{
-		m.M11, m.M21, m.M31, m.M41,
-		m.M12, m.M22, m.M32, m.M42,
-		m.M13, m.M23, m.M33, m.M43,
-		m.M14, m.M24, m.M34, m.M44,
-	}
-}
-
 func (m Mat4) Scale() Vec3 {
 	return NewVec3(
 		m.OrientationX().Length(),
@@ -413,6 +395,40 @@ func (m Mat4) Rotation() Quat {
 		w = (m.M32 - m.M23) / (4 * x)
 	}
 	return UnitQuat(NewQuat(w, x, y, z))
+}
+
+func (m Mat4) TRS() (Vec3, Quat, Vec3) {
+	translation := m.Translation()
+	scale := m.Scale()
+	m.M11 /= scale.X
+	m.M21 /= scale.X
+	m.M31 /= scale.X
+	m.M12 /= scale.Y
+	m.M22 /= scale.Y
+	m.M32 /= scale.Y
+	m.M13 /= scale.Z
+	m.M23 /= scale.Z
+	m.M33 /= scale.Z
+	rotation := m.Rotation()
+	return translation, rotation, scale
+}
+
+func (m Mat4) RowMajorArray() [16]float32 {
+	return [16]float32{
+		m.M11, m.M12, m.M13, m.M14,
+		m.M21, m.M22, m.M23, m.M24,
+		m.M31, m.M32, m.M33, m.M34,
+		m.M41, m.M42, m.M43, m.M44,
+	}
+}
+
+func (m Mat4) ColumnMajorArray() [16]float32 {
+	return [16]float32{
+		m.M11, m.M21, m.M31, m.M41,
+		m.M12, m.M22, m.M32, m.M42,
+		m.M13, m.M23, m.M33, m.M43,
+		m.M14, m.M24, m.M34, m.M44,
+	}
 }
 
 func (m Mat4) GoString() string {

--- a/sprec/mat4.go
+++ b/sprec/mat4.go
@@ -374,7 +374,11 @@ func (m Mat4) Scale() Vec3 {
 	)
 }
 
-func (m Mat4) RotationQuat() Quat {
+// Rotation returns the rotation that is represented by this matrix.
+// NOTE: This function assumes that the matrix has identity scale. If you
+// want to get the rotation of a matrix that has non-identity scale, consider
+// using the TRS method.
+func (m Mat4) Rotation() Quat {
 	// This is calculated by inversing the equations for
 	// quat.OrientationX, quat.OrientationY and quat.OrientationZ.
 

--- a/sprec/mat4_test.go
+++ b/sprec/mat4_test.go
@@ -322,13 +322,13 @@ var _ = Describe("Mat4", func() {
 		))
 	})
 
-	Specify("#RotationQuat", func() {
+	Specify("#Rotation", func() {
 		matrix = IdentityMat4()
-		quat := matrix.RotationQuat()
+		quat := matrix.Rotation()
 		Expect(quat).To(HaveQuatCoords(1.0, 0.0, 0.0, 0.0))
 
 		matrix = RotationMat4(Degrees(30), 0.0, 1.0, 0.0)
-		quat = matrix.RotationQuat()
+		quat = matrix.Rotation()
 		rotatedVector := QuatVec3Rotation(quat, NewVec3(1.0, 0.0, 0.0))
 		Expect(rotatedVector).To(HaveVec3Coords(0.86602540378443870761, 0.0, -0.5))
 	})

--- a/sprec/mat4_test.go
+++ b/sprec/mat4_test.go
@@ -53,6 +53,16 @@ var _ = Describe("Mat4", func() {
 		Expect(transformedVector).To(HaveVec4Coords(vector.X, vector.Y, vector.Z, vector.W))
 	})
 
+	Specify("TransposedMat4", func() {
+		result := TransposedMat4(matrix)
+		Expect(result).To(HaveMat4Elements(
+			0.1, 0.5, 0.9, 1.3,
+			0.2, 0.6, 1.0, 1.4,
+			0.3, 0.7, 1.1, 1.5,
+			0.4, 0.8, 1.2, 1.6,
+		))
+	})
+
 	Specify("TranslationMat4", func() {
 		translationMatrix := TranslationMat4(2.0, -3.0, 4.0)
 		transformedVector := Mat4Vec4Prod(translationMatrix, vector)

--- a/sprec/mat4_test.go
+++ b/sprec/mat4_test.go
@@ -333,6 +333,18 @@ var _ = Describe("Mat4", func() {
 		Expect(rotatedVector).To(HaveVec3Coords(0.86602540378443870761, 0.0, -0.5))
 	})
 
+	Specify("#TRS", func() {
+		translation := NewVec3(15.0, 5.0, -3.0)
+		rotation := RotationQuat(Degrees(30), BasisXVec3())
+		scale := NewVec3(0.1, 0.5, 0.3)
+		matrix := TRSMat4(translation, rotation, scale)
+
+		t, r, s := matrix.TRS()
+		Expect(t).To(HaveVec3Coords(translation.X, translation.Y, translation.Z))
+		Expect(r).To(HaveQuatCoords(rotation.W, rotation.X, rotation.Y, rotation.Z))
+		Expect(s).To(HaveVec3Coords(scale.X, scale.Y, scale.Z))
+	})
+
 	Specify("#RowMajorArray", func() {
 		array := matrix.RowMajorArray()
 		Expect(array[0]).To(EqualFloat32(0.1))

--- a/sprec/util.go
+++ b/sprec/util.go
@@ -7,25 +7,25 @@ const (
 	Epsilon = float32(0.000001)
 )
 
-func Abs(value float32) float32 {
-	return math.Float32frombits(math.Float32bits(value) &^ (1 << 31))
+func Abs[T ~float32](value T) T {
+	return T(math.Float32frombits(math.Float32bits(float32(value)) &^ (1 << 31)))
 }
 
-func Max(a, b float32) float32 {
+func Max[T ~float32](a, b T) T {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func Min(a, b float32) float32 {
+func Min[T ~float32](a, b T) T {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func Clamp(value, min, max float32) float32 {
+func Clamp[T ~float32](value, min, max T) T {
 	if value < min {
 		return min
 	}
@@ -35,8 +35,8 @@ func Clamp(value, min, max float32) float32 {
 	return value
 }
 
-func Mix(a, b, amount float32) float32 {
-	return a*(1.0-amount) + b*amount
+func Mix[T ~float32](a, b T, amount float32) T {
+	return T(float32(a)*(1.0-amount) + float32(b)*amount)
 }
 
 func Eq(a, b float32) bool {

--- a/sprec/util_test.go
+++ b/sprec/util_test.go
@@ -13,33 +13,33 @@ import (
 var _ = Describe("Util", func() {
 
 	Specify("Abs", func() {
-		Expect(Abs(-0.1)).To(EqualFloat32(0.1))
-		Expect(Abs(-13.57)).To(EqualFloat32(13.57))
-		Expect(Abs(11.01)).To(EqualFloat32(11.01))
+		Expect(Abs(float32(-0.1))).To(EqualFloat32(0.1))
+		Expect(Abs(float32(-13.57))).To(EqualFloat32(13.57))
+		Expect(Abs(float32(11.01))).To(EqualFloat32(11.01))
 	})
 
 	Specify("Max", func() {
-		Expect(Max(1.0, 2.0)).To(EqualFloat32(2.0))
-		Expect(Max(1.0, -1.0)).To(EqualFloat32(1.0))
-		Expect(Max(5.0, 5.0)).To(EqualFloat32(5.0))
+		Expect(Max(float32(1.0), float32(2.0))).To(EqualFloat32(2.0))
+		Expect(Max(float32(1.0), float32(-1.0))).To(EqualFloat32(1.0))
+		Expect(Max(float32(5.0), float32(5.0))).To(EqualFloat32(5.0))
 	})
 
 	Specify("Min", func() {
-		Expect(Min(1.0, 2.0)).To(EqualFloat32(1.0))
-		Expect(Min(1.0, -1.0)).To(EqualFloat32(-1.0))
-		Expect(Min(5.0, 5.0)).To(EqualFloat32(5.0))
+		Expect(Min(float32(1.0), float32(2.0))).To(EqualFloat32(1.0))
+		Expect(Min(float32(1.0), float32(-1.0))).To(EqualFloat32(-1.0))
+		Expect(Min(float32(5.0), float32(5.0))).To(EqualFloat32(5.0))
 	})
 
 	Specify("Clamp", func() {
-		Expect(Clamp(1.0, 2.0, 3.0)).To(EqualFloat32(2.0))
-		Expect(Clamp(2.5, 2.0, 3.0)).To(EqualFloat32(2.5))
-		Expect(Clamp(4.0, 2.0, 3.0)).To(EqualFloat32(3.0))
+		Expect(Clamp(float32(1.0), float32(2.0), float32(3.0))).To(EqualFloat32(2.0))
+		Expect(Clamp(float32(2.5), float32(2.0), float32(3.0))).To(EqualFloat32(2.5))
+		Expect(Clamp(float32(4.0), float32(2.0), float32(3.0))).To(EqualFloat32(3.0))
 	})
 
 	Specify("Mix", func() {
-		Expect(Mix(1.0, 2.0, 0.0)).To(EqualFloat32(1.0))
-		Expect(Mix(1.0, 2.0, 1.0)).To(EqualFloat32(2.0))
-		Expect(Mix(1.0, 2.0, 0.5)).To(EqualFloat32(1.5))
+		Expect(Mix(float32(1.0), float32(2.0), float32(0.0))).To(EqualFloat32(1.0))
+		Expect(Mix(float32(1.0), float32(2.0), float32(1.0))).To(EqualFloat32(2.0))
+		Expect(Mix(float32(1.0), float32(2.0), float32(0.5))).To(EqualFloat32(1.5))
 	})
 
 	Specify("Eq", func() {


### PR DESCRIPTION
This PR adds new functions to the matrix types, it makes a breaking change by renaming the `RotationQuat` method to `Rotation`, and makes some utility functions generic so that they can be used with Angles as well.
