### PR TITLE
Switch the direction returned by NormalVec2

### DIFF
--- a/dprec/vec2.go
+++ b/dprec/vec2.go
@@ -126,11 +126,14 @@ func InverseVec2(vector Vec2) Vec2 {
 	}
 }
 
-// NormalVec2 returns a unit vector perpendicular to the given vector.
+// NormalVec2 returns a unit vector perpendicular to the given vector,
+// rotated 90 degrees clockwise (the right-hand perpendicular). When the
+// given vector is an edge of a counter-clockwise wound polygon, the
+// returned normal points outward.
 func NormalVec2(vector Vec2) Vec2 {
 	return UnitVec2(Vec2{
-		X: -vector.Y,
-		Y: vector.X,
+		X: vector.Y,
+		Y: -vector.X,
 	})
 }
 

--- a/dprec/vec2_test.go
+++ b/dprec/vec2_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Vec2", func() {
 		result := NormalVec2(firstVector)
 		Expect(Vec2Dot(firstVector, result)).To(EqualFloat64(0.0))
 		Expect(result.Length()).To(EqualFloat64(1.0))
+		Expect(result).To(HaveVec2Coords(0.8320502943378437, -0.5547001962252291))
 	})
 
 	Specify("ArrayToVec2", func() {

--- a/sprec/vec2.go
+++ b/sprec/vec2.go
@@ -126,11 +126,14 @@ func InverseVec2(vector Vec2) Vec2 {
 	}
 }
 
-// NormalVec2 returns a unit vector perpendicular to the given vector.
+// NormalVec2 returns a unit vector perpendicular to the given vector,
+// rotated 90 degrees clockwise (the right-hand perpendicular). When the
+// given vector is an edge of a counter-clockwise wound polygon, the
+// returned normal points outward.
 func NormalVec2(vector Vec2) Vec2 {
 	return UnitVec2(Vec2{
-		X: -vector.Y,
-		Y: vector.X,
+		X: vector.Y,
+		Y: -vector.X,
 	})
 }
 

--- a/sprec/vec2_test.go
+++ b/sprec/vec2_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Vec2", func() {
 		result := NormalVec2(firstVector)
 		Expect(Vec2Dot(firstVector, result)).To(EqualFloat32(0.0))
 		Expect(result.Length()).To(EqualFloat32(1.0))
+		Expect(result).To(HaveVec2Coords(0.832050294, -0.554700196))
 	})
 
 	Specify("ArrayToVec2", func() {


### PR DESCRIPTION
## Changes

**Breaking Change**: Makes it so that `NormalVec2` returns a perpendicular unit vector that points outwards when used in a counter-clockwise oriented triangle.
